### PR TITLE
Notify on going offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ Node.JS script sending slack message when selected twitch channel start to strea
 - `clientToken` : Application's client_id, requested by Twich API. You have to [register](https://www.twitch.tv/kraken/oauth2/clients/new) your application to get one.
 - `chaineID` : Name of the watched stream (`ogaminglol` in `https://www.twitch.tv/ogaminglol`). Could be a single string or an array of string, to watch multiple stream.
 - `notificationOnStatusChange` : Set to `true` or `false` to enable or to disable the notification if the status (name) of the stream change.
+- `notificationOnGoingOffline` : Set to `true` or `false` to enable or to disable the notification if a watched stream goes offline.
 - `slackHookUrl` :  Link to your Slack incoming-webhooks.
 - `slackHookName` :  Name to display when you will get notified on Slack.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ let twitchAPILink = require('./config.json').twitchAPILink;
 let channelID = require('./config.json').chaineID;
 let clientToken = require('./config.json').clientToken;
 let notificationOnStatusChange = require('./config.json').notificationOnStatusChange;
+let notificationOnGoingOffline = require('./config.json').notificationOnGoingOffline;
 let slackUrl = require('./config.json').slackHookUrl;
 let slackName = require('./config.json').slackHookName;
 
@@ -23,27 +24,45 @@ function getSaveFilename(targetChannelID) {
 
 // Perform update of the last stream ID file
 function updateSavedData(targetChannelID, newData, savedData) {
-  if (typeof savedData[targetChannelID] === 'undefined') {
-    savedData[targetChannelID] = {};
-  }
-  savedData[targetChannelID].id = newData.stream._id
-  savedData[targetChannelID].status = newData.stream.channel.status
+
   if (fs.existsSync(getSaveFilename(targetChannelID))) {
     fs.unlinkSync(getSaveFilename(targetChannelID));
   }
-  fs.writeFileSync(getSaveFilename(targetChannelID), JSON.stringify(savedData));
+
+  if (typeof savedData[targetChannelID] === 'undefined') {
+    savedData[targetChannelID] = {};
+  }
+
+  if (newData.stream) {
+    savedData[targetChannelID].id = newData.stream._id
+    savedData[targetChannelID].status = newData.stream.channel.status
+    if (fs.existsSync(getSaveFilename(targetChannelID))) {
+      fs.unlinkSync(getSaveFilename(targetChannelID));
+    }
+    fs.writeFileSync(getSaveFilename(targetChannelID), JSON.stringify(savedData));
+  }
+
 }
 
 // Send the slack message to the config's webhook
 function sendSlackMessage(targetChannelID, data, baseText) {
-  let text = '*' + data.stream.channel.display_name + '*' + baseText;
-  text += data.stream.channel.status + ' (' + data.stream.channel.game + ')' + '\n';
-  text += '<' + data.stream.channel.url + '>';
-  let msgParameters = {
-    username: slackName,
-    icon_emoji: data.stream.channel.logo,
-    text: text,
-  };
+  let msgParameters = {};
+  if (data.stream) {
+    let text = '*' + data.stream.channel.display_name + '*' + baseText;
+    text += data.stream.channel.status + ' (' + data.stream.channel.game + ')' + '\n';
+    text += '<' + data.stream.channel.url + '>';
+    msgParameters = {
+      username: slackName,
+      icon_emoji: data.stream.channel.logo,
+      text: text,
+    };
+  } else {
+      let text = '*' + targetChannelID + '*' + baseText;
+      msgParameters = {
+	  username: slackName,
+	  text: text,
+      };
+  }
   let slack = new Slack();
   slack.setWebhook(slackUrl);
   slack.webhook(msgParameters, function (err, response) {
@@ -66,11 +85,18 @@ function performOnlineCheck(targetChannelID) {
     let data = JSON.parse(html);
 
     let savedData = {};
+    let saveFileExists = 0;
     if (fs.existsSync(getSaveFilename(targetChannelID))) {
       savedData = JSON.parse(fs.readFileSync(getSaveFilename(targetChannelID), 'utf8'))
+      saveFileExists = 1;
     }
 
-    if (data.stream !== null) {
+    if (data.stream == null) {
+      if (notificationOnGoingOffline && saveFileExists ) {
+        updateSavedData(targetChannelID, data, savedData);
+        sendSlackMessage(targetChannelID, data, ' stopped streaming');
+      }
+    } else {
       if (savedData.length === 0 || typeof savedData[targetChannelID] === 'undefined' || savedData[targetChannelID].id !== data.stream._id) {
         updateSavedData(targetChannelID, data, savedData);
         sendSlackMessage(targetChannelID, data, ' started to stream : ');


### PR DESCRIPTION
This adds a new config option which, if set to `true`, will post a notification to Slack when a watched stream goes offline.

Behavioral change: The script will erase the save-file of a watched stream that goes offline. (Rather than its current behavior of leaving the file there with a stale stream ID.)